### PR TITLE
get_info doesn't exist

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ fn main() {
         Err(e) => { panic!("{}", e); }
     };
 
-    let info = match docker.get_info() {
+    let info = match docker.get_system_info() {
         Ok(info) => info,
         Err(e) => { panic!("{}", e); }
     };


### PR DESCRIPTION
Hey,

was just going through the README and found this method that doesn't exist.

I'm guessing you meant get_system_info
