### PR TITLE
updates openssl to 0.7

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,6 @@ readme = "README.md"
 keywords = ["docker"]
 
 [dependencies]
-openssl = "0.6.7"
+openssl = "0.7"
 unix_socket = "0.4.6"
 rustc-serialize = "0.3.16"

--- a/src/tcp.rs
+++ b/src/tcp.rs
@@ -64,7 +64,7 @@ impl TcpStream {
         }
         
         let stream = self.stream.try_clone().unwrap();
-        let ssl_stream = match openssl::ssl::SslStream::new(&context, stream) {
+        let ssl_stream = match openssl::ssl::SslStream::connect(&context, stream) {
             Ok(ssl_stream) => ssl_stream,
             Err(e) => {
                 let err = std::io::Error::new(std::io::ErrorKind::NotConnected,


### PR DESCRIPTION
This update is required as the current version fails to compile because of TLSv3